### PR TITLE
Replace `.all` imports

### DIFF
--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -13,7 +13,7 @@ from os.path import abspath, dirname
 from time import sleep
 
 from sage.algebras.quatalg.all import QuaternionAlgebra
-from sage.arith.all import lcm
+from sage.arith.functions import lcm
 from sage.functions.generalized import sgn
 from sage.functions.hyperbolic import acosh
 from sage.functions.trig import arctan
@@ -21,15 +21,17 @@ from sage.geometry.hyperbolic_space.hyperbolic_geodesic import HyperbolicGeodesi
 from sage.geometry.hyperbolic_space.hyperbolic_interface import HyperbolicPlane
 from sage.groups.free_group import FreeGroup
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cached_method, walltime
+from sage.misc.cachefunc import cached_method
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
 from sage.misc.sage_eval import sage_eval
 from sage.misc.verbose import verbose
 from sage.modular.arithgroup.congroup_sl2z import SL2Z
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.fg_pid.fgp_module import FGP_Module
 from sage.modules.free_module import FreeModule_generic
 from sage.plot.hyperbolic_arc import hyperbolic_arc
@@ -37,18 +39,16 @@ from sage.plot.hyperbolic_polygon import hyperbolic_polygon, hyperbolic_triangle
 from sage.plot.plot import plot
 from sage.plot.point import point2d
 from sage.repl.rich_output.pretty_print import show
-from sage.rings.all import (
-    AA,
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-)
+from sage.rings.qqbar import AA
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.padics.factory import Qp
 from sage.rings.infinity import Infinity
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.sage_object import SageObject, load, save

--- a/darmonpoints/arithgroup_element.py
+++ b/darmonpoints/arithgroup_element.py
@@ -13,23 +13,24 @@ from sage.algebras.quatalg.all import QuaternionAlgebra
 from sage.functions.generalized import sgn
 from sage.functions.trig import arctan
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
-from sage.misc.all import cached_method, lazy_attribute, walltime
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.free_module import FreeModule_generic
-from sage.rings.all import (
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-)
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.padics.factory import Qp
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.richcmp import richcmp

--- a/darmonpoints/arithgroup_generic.py
+++ b/darmonpoints/arithgroup_generic.py
@@ -9,36 +9,36 @@ from collections import defaultdict
 from itertools import chain, groupby, islice, product, starmap, tee
 
 from sage.algebras.quatalg.all import QuaternionAlgebra
-from sage.arith.all import lcm
+from sage.arith.functions import lcm
 from sage.functions.generalized import sgn
 from sage.functions.trig import arctan
 from sage.geometry.hyperbolic_space.hyperbolic_geodesic import HyperbolicGeodesicUHP
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cached_method, walltime
+from sage.misc.cachefunc import cached_method
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
 from sage.misc.sage_eval import sage_eval
 from sage.misc.verbose import get_verbose, set_verbose, verbose
 from sage.modular.arithgroup.congroup_sl2z import SL2Z
 from sage.modular.modsym.p1list import P1List, lift_to_sl2z
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.fg_pid.fgp_module import FGP_Module
 from sage.modules.free_module import FreeModule_generic
-from sage.rings.all import (
-    AA,
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-)
+from sage.rings.qqbar import AA
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
 from sage.rings.infinity import Infinity
+from sage.rings.padics.factory import Qp
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.sage_object import SageObject, load, save
 from sage.structure.unique_representation import UniqueRepresentation

--- a/darmonpoints/arithgroup_nscartan.py
+++ b/darmonpoints/arithgroup_nscartan.py
@@ -12,37 +12,37 @@ from sage.algebras.quatalg.all import QuaternionAlgebra
 from sage.functions.generalized import sgn
 from sage.functions.trig import arctan
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.constructor import (
     block_diagonal_matrix,
     diagonal_matrix,
     identity_matrix,
 )
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cached_method, walltime
+from sage.misc.cachefunc import cached_method
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
 from sage.misc.sage_eval import sage_eval
 from sage.misc.verbose import verbose
 from sage.modular.arithgroup.congroup_sl2z import SL2Z
 from sage.modular.modsym.p1list import lift_to_sl2z
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.fg_pid.fgp_module import FGP_Module
 from sage.modules.free_module import FreeModule_generic
-from sage.rings.all import (
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-    Zmod,
-)
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
 from sage.rings.finite_rings.finite_field_constructor import FiniteField
 from sage.rings.infinity import Infinity as oo
+from sage.rings.padics.factory import Qp
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.sage_object import SageObject, load, save

--- a/darmonpoints/cohomology_abstract.py
+++ b/darmonpoints/cohomology_abstract.py
@@ -22,18 +22,15 @@ from sage.misc.verbose import verbose
 from sage.modules.free_module_element import free_module_element, vector
 from sage.modules.module import Module
 from sage.parallel.decorate import fork, parallel
-from sage.rings.all import (
-    RR,
-    ComplexField,
-    LaurentSeriesRing,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-    Zmod,
-    Zp,
-)
+from sage.rings.real_mpfr import RR
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.laurent_series_ring import LaurentSeriesRing
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
 from sage.rings.number_field.number_field import NumberField
+from sage.rings.padics.factory import Qp, Zp
 from sage.rings.padics.precision_error import PrecisionError
 from sage.structure.element import ModuleElement, MultiplicativeGroupElement
 from sage.structure.parent import Parent

--- a/darmonpoints/darmonpoints.py
+++ b/darmonpoints/darmonpoints.py
@@ -9,10 +9,14 @@ from itertools import product
 
 from sage.algebras.quatalg.quaternion_algebra import QuaternionAlgebra
 from sage.arith.misc import factor, fundamental_discriminant
-from sage.misc.all import walltime
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
-from sage.rings.all import QQ, RR, ZZ, Qp, Zmod
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
+from sage.rings.padics.factory import Qp
 from sage.rings.infinity import Infinity
 from sage.rings.number_field.number_field import is_fundamental_discriminant
 from sage.rings.padics.precision_error import PrecisionError

--- a/darmonpoints/divisors.py
+++ b/darmonpoints/divisors.py
@@ -3,9 +3,10 @@ import os
 from collections import defaultdict
 from itertools import chain, groupby, islice, product, starmap, tee
 
-from sage.arith.all import GCD
+from sage.arith.misc import GCD
 from sage.categories.action import Action
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.matrix_space import MatrixSpace
 from sage.misc.cachefunc import cached_method
 from sage.misc.misc_c import prod

--- a/darmonpoints/findcurve.py
+++ b/darmonpoints/findcurve.py
@@ -6,7 +6,12 @@ import datetime
 import os
 import sys
 
-from sage.all import QQ, ZZ, Infinity, Qp, QuaternionAlgebra, factor
+from sage.rings.rational_field import Q as QQ
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.infinity import Infinity
+from sage.rings.padics.factory import Qp
+from sage.algebras.quatalg.quaternion_algebra import QuaternionAlgebra
+from sage.arith.misc import factor
 from sage.misc.verbose import get_verbose, set_verbose, verbose
 from sage.rings.padics.precision_error import PrecisionError
 

--- a/darmonpoints/homology.py
+++ b/darmonpoints/homology.py
@@ -9,9 +9,10 @@ from collections import defaultdict
 from copy import deepcopy
 from itertools import chain, groupby, islice, product, starmap, tee
 
-from sage.arith.all import GCD
+from sage.arith.misc import GCD
 from sage.categories.action import Action
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.matrix.matrix_space import MatrixSpace
 from sage.misc.cachefunc import cached_method
 from sage.misc.verbose import verbose

--- a/darmonpoints/homology_abstract.py
+++ b/darmonpoints/homology_abstract.py
@@ -10,7 +10,8 @@ from collections import defaultdict
 from itertools import chain, groupby, islice, product, starmap, tee
 
 from sage.categories.action import Action
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.misc.cachefunc import cached_method
 from sage.misc.verbose import verbose
 from sage.modules.free_module_element import vector

--- a/darmonpoints/integrals.py
+++ b/darmonpoints/integrals.py
@@ -7,22 +7,20 @@ from collections import defaultdict
 from itertools import chain, groupby, islice, product, starmap, tee
 from operator import mul
 
-from sage.all import prod
+from sage.misc.misc_c import prod
 from sage.arith.misc import algdep
 from sage.misc.misc import cputime
 from sage.misc.verbose import verbose
 from sage.parallel.decorate import fork, parallel
-from sage.rings.all import (
-    RR,
-    ComplexField,
-    Infinity,
-    LaurentSeriesRing,
-    PolynomialRing,
-    PowerSeriesRing,
-    QuadraticField,
-    RealField,
-    Zmod,
-)
+from sage.rings.real_mpfr import RR
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.infinity import Infinity
+from sage.rings.laurent_series_ring import LaurentSeriesRing
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.power_series_ring import PowerSeriesRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
 from sage.structure.sage_object import SageObject
 
 from .limits import find_center, num_evals

--- a/darmonpoints/limits.py
+++ b/darmonpoints/limits.py
@@ -3,17 +3,16 @@ from operator import itemgetter, mul
 
 from sage.functions.other import floor
 from sage.groups.generic import discrete_log
-from sage.matrix.all import Matrix, matrix
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
 from sage.misc.misc_c import prod
 from sage.misc.verbose import verbose
-from sage.rings.all import (
-    RR,
-    ComplexField,
-    PolynomialRing,
-    QuadraticField,
-    RealField,
-    Zmod,
-)
+from sage.rings.real_mpfr import RR
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
 
 from .util import *
 

--- a/darmonpoints/meromorphic.py
+++ b/darmonpoints/meromorphic.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/meromorphic_debug.py
+++ b/darmonpoints/meromorphic_debug.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/meromorphic_list.py
+++ b/darmonpoints/meromorphic_list.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/meromorphic_ps.py
+++ b/darmonpoints/meromorphic_ps.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
+from sage.rings.integer import Integer
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/meromorphic_ps_dlog.py
+++ b/darmonpoints/meromorphic_ps_dlog.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/meromorphic_ps_log.py
+++ b/darmonpoints/meromorphic_ps_log.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/mixed_extension.pyx
+++ b/darmonpoints/mixed_extension.pyx
@@ -1,5 +1,5 @@
 from sage.categories.fields import Fields
-from sage.rings.all import QQ
+from sage.rings.rational_field import Q as QQ
 from sage.rings.integer_ring import Z as ZZ
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.ring import Field
@@ -18,18 +18,16 @@ from bisect import bisect_left as bisect
 from math import atan as atan
 
 from sage.matrix.constructor import Matrix
-from sage.rings.all import (
-    AA,
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-)
+from sage.rings.qqbar import AA
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.padics.factory import Qp
 
 
 def get_word_rep_fast(self, delta, Pold=None):

--- a/darmonpoints/my_p1list_nf.py
+++ b/darmonpoints/my_p1list_nf.py
@@ -452,7 +452,7 @@ def my_p1NFlist(N):
     # N.residues() = iterator through the residues mod N
     L = L + [MyMSymbol(k(1), r) for r in N.residues()]
 
-    from sage.arith.all import divisors
+    from sage.arith.misc import divisors
 
     for D in divisors(N):
         if not D.is_trivial() and D != N:
@@ -656,7 +656,7 @@ def psi(N):
     if not N.is_integral():
         raise ValueError("psi only defined for integral ideals")
 
-    from sage.misc.all import prod
+    from sage.misc.misc_c import prod
 
     return prod(
         [

--- a/darmonpoints/ocbianchi.py
+++ b/darmonpoints/ocbianchi.py
@@ -23,11 +23,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.power_series_ring import PowerSeriesRing
 from sage.rings.rational_field import QQ

--- a/darmonpoints/ocmodule.py
+++ b/darmonpoints/ocmodule.py
@@ -11,7 +11,7 @@ from sage.categories.action import Action
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -19,11 +19,11 @@ from sage.modular.pollack_stevens.sigma0 import Sigma0, Sigma0ActionAdjuster
 from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import Qp, ZpCA
+from sage.rings.padics.factory import Qp, Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.rings.power_series_ring import PowerSeriesRing

--- a/darmonpoints/plectic.py
+++ b/darmonpoints/plectic.py
@@ -7,29 +7,29 @@ from itertools import chain, groupby, islice, product, starmap, tee
 from sage.algebras.quatalg.all import QuaternionAlgebra
 from sage.functions.trig import arctan
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
-from sage.misc.all import cached_method, lazy_attribute, walltime
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
 from sage.modular.arithgroup.congroup_gamma0 import Gamma0_constructor as Gamma0
 from sage.modular.btquotients.btquotient import BruhatTitsTree
 from sage.modular.cusps import Cusp
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.free_module import FreeModule_generic
 from sage.parallel.decorate import parallel
-from sage.rings.all import (
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    Qq,
-    QuadraticField,
-    RealField,
-    Zmod,
-)
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
+from sage.rings.padics.factory import Qp, Qq
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.sage_object import SageObject, load, save

--- a/darmonpoints/rationalfunctions.py
+++ b/darmonpoints/rationalfunctions.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 from sage.categories.pushout import pushout
 from sage.matrix.constructor import Matrix
 from sage.matrix.matrix_space import MatrixSpace
-from sage.misc.all import cputime
+from sage.misc.timing import cputime
 from sage.misc.cachefunc import cached_function, cached_method
 from sage.misc.misc_c import prod
 from sage.misc.verbose import get_verbose, set_verbose, verbose
@@ -18,11 +18,11 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense
 from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.module import Module
 from sage.modules.vector_integer_dense import Vector_integer_dense
-from sage.rings.all import Integer, Zp
+from sage.rings.integer import Integer
 from sage.rings.finite_rings.integer_mod_ring import Zmod
 from sage.rings.infinity import Infinity
 from sage.rings.integer_ring import ZZ
-from sage.rings.padics.factory import ZpCA
+from sage.rings.padics.factory import Zp, ZpCA
 from sage.rings.padics.padic_generic import pAdicGeneric
 from sage.rings.padics.precision_error import PrecisionError
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing

--- a/darmonpoints/representations.py
+++ b/darmonpoints/representations.py
@@ -21,18 +21,15 @@ from sage.modules.free_module_element import FreeModuleElement_generic_dense, ve
 from sage.modules.vector_integer_dense import Vector_integer_dense
 from sage.modules.vector_rational_dense import Vector_rational_dense
 from sage.parallel.decorate import fork, parallel
-from sage.rings.all import (
-    RR,
-    ComplexField,
-    LaurentSeriesRing,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-    Zmod,
-    Zp,
-)
+from sage.rings.real_mpfr import RR
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.laurent_series_ring import LaurentSeriesRing
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
 from sage.rings.number_field.number_field import NumberField
+from sage.rings.padics.factory import Qp, Zp
 from sage.structure.element import ModuleElement, MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.richcmp import richcmp

--- a/darmonpoints/sarithgroup.py
+++ b/darmonpoints/sarithgroup.py
@@ -12,29 +12,29 @@ from os.path import dirname
 from sage.algebras.quatalg.all import QuaternionAlgebra
 from sage.functions.trig import arctan
 from sage.groups.group import AlgebraicGroup
-from sage.matrix.all import Matrix, matrix
-from sage.misc.all import cached_method, lazy_attribute, walltime
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.lazy_attribute import lazy_attribute
+from sage.misc.timing import walltime
 from sage.misc.misc_c import prod
 from sage.misc.persist import db
 from sage.misc.verbose import verbose
 from sage.modular.arithgroup.congroup_gamma0 import Gamma0_constructor as Gamma0
 from sage.modular.btquotients.btquotient import BruhatTitsTree
 from sage.modular.cusps import Cusp
-from sage.modules.all import vector
+from sage.modules.free_module_element import free_module_element as vector
 from sage.modules.free_module import FreeModule_generic
-from sage.rings.all import (
-    QQ,
-    RR,
-    ZZ,
-    ComplexField,
-    NumberField,
-    PolynomialRing,
-    Qp,
-    Qq,
-    QuadraticField,
-    RealField,
-    Zmod,
-)
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.number_field.number_field import NumberField
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
+from sage.rings.padics.factory import Qp, Qq
 from sage.structure.element import MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.sage_object import SageObject, load, save

--- a/darmonpoints/schottky.py
+++ b/darmonpoints/schottky.py
@@ -14,7 +14,8 @@ from sage.misc.latex import latex
 from sage.misc.lazy_attribute import lazy_attribute
 from sage.misc.verbose import verbose
 from sage.modules.module import Module
-from sage.rings.all import ZZ, IntegerRing
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.integer_ring import IntegerRing
 from sage.rings.infinity import Infinity
 from sage.rings.semirings.non_negative_integer_semiring import NN
 from sage.sets.set import Set

--- a/darmonpoints/theta.py
+++ b/darmonpoints/theta.py
@@ -9,7 +9,8 @@ from sage.misc.cachefunc import cached_method
 from sage.misc.latex import latex
 from sage.misc.verbose import verbose
 from sage.modules.module import Module
-from sage.rings.all import ZZ, IntegerRing
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.integer_ring import IntegerRing
 from sage.rings.infinity import Infinity
 from sage.rings.semirings.non_negative_integer_semiring import NN
 from sage.sets.set import Set

--- a/darmonpoints/util.py
+++ b/darmonpoints/util.py
@@ -6,7 +6,9 @@ from functools import reduce
 from itertools import chain, groupby, islice, product, starmap, tee
 
 from sage.algebras.quatalg.quaternion_algebra import QuaternionAlgebra
-from sage.arith.all import divisors, kronecker_symbol, next_prime
+from sage.arith.misc import divisors
+from sage.arith.misc import kronecker as kronecker_symbol
+from sage.arith.misc import next_prime
 from sage.arith.functions import lcm
 from sage.arith.misc import valuation
 from sage.calculus.var import var
@@ -14,8 +16,10 @@ from sage.functions.generalized import sgn
 from sage.functions.transcendental import Function_zeta
 from sage.interfaces.gp import gp
 from sage.libs.pari.all import PariError, pari
-from sage.matrix.all import Matrix, matrix
-from sage.misc.all import cached_method, cartesian_product_iterator
+from sage.matrix.constructor import Matrix
+from sage.matrix.constructor import Matrix as matrix
+from sage.misc.cachefunc import cached_method
+from sage.misc.mrange import cartesian_product_iterator
 from sage.misc.cachefunc import cached_function
 from sage.misc.functional import cyclotomic_polynomial
 from sage.misc.latex import LatexExpr, latex
@@ -24,11 +28,16 @@ from sage.misc.sage_eval import sage_eval
 from sage.misc.verbose import get_verbose, set_verbose, verbose
 from sage.modular.modform.constructor import CuspForms, EisensteinForms
 from sage.modules.fg_pid.fgp_module import FGP_Module, FGP_Module_class
-from sage.rings.all import CC, QQ, RR, ZZ, Qp, RealField
+from sage.rings.cc import CC
+from sage.rings.rational_field import Q as QQ
+from sage.rings.real_mpfr import RR
+from sage.rings.integer_ring import Z as ZZ
+from sage.rings.real_mpfr import RealField
 from sage.rings.big_oh import O
 from sage.rings.fast_arith import prime_range
 from sage.rings.finite_rings.integer_mod_ring import IntegerModRing, Zmod
 from sage.rings.infinity import Infinity
+from sage.rings.padics.factory import Qp
 from sage.rings.padics.padic_generic import local_print_mode
 from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
 from sage.schemes.elliptic_curves.constructor import (


### PR DESCRIPTION
This is preparation for using this package with the modularized distributions of the Sage library from passagemath.