### PR TITLE
Support for using the modularized distributions from the passagemath project

### DIFF
--- a/_doctest_environment.py
+++ b/_doctest_environment.py
@@ -1,0 +1,6 @@
+# Toplevel for doctesting with passagemath
+
+from sage.all__sagemath_flint import *
+from sage.all__sagemath_pari import *
+from sage.all__sagemath_modules import *
+from sage.all__sagemath_symbolics import *

--- a/_doctest_environment.py
+++ b/_doctest_environment.py
@@ -3,4 +3,5 @@
 from sage.all__sagemath_flint import *
 from sage.all__sagemath_pari import *
 from sage.all__sagemath_modules import *
+from sage.all__sagemath_schemes import *
 from sage.all__sagemath_symbolics import *

--- a/darmonpoints/__init__.py
+++ b/darmonpoints/__init__.py
@@ -1,5 +1,8 @@
 # Add the import for which you want to give a direct access
-from sage.all_cmdline import *
+try:
+    from sage.all_cmdline import *
+except ImportError:
+    from sage.all__sagemath_modules import *
 
 from .cohomology_arithmetic import (
     ArithCoh,

--- a/darmonpoints/cohomology_arithmetic.py
+++ b/darmonpoints/cohomology_arithmetic.py
@@ -32,7 +32,10 @@ from collections import defaultdict
 from itertools import chain, groupby, islice, product, starmap, tee
 from time import sleep
 
-from sage.arith.all import dedekind_sum, gcd, lcm, xgcd
+from sage.arith.misc import dedekind_sum
+from sage.arith.misc import GCD as gcd
+from sage.arith.functions import lcm
+from sage.arith.misc import XGCD as xgcd
 from sage.categories.action import Action
 from sage.categories.homset import Hom
 from sage.groups.group import AlgebraicGroup
@@ -46,21 +49,18 @@ from sage.modular.pollack_stevens.distributions import OverconvergentDistributio
 from sage.modular.pollack_stevens.padic_lseries import log_gamma_binomial
 from sage.modules.free_module_element import free_module_element, vector
 from sage.parallel.decorate import fork, parallel
-from sage.rings.all import (
-    RR,
-    ComplexField,
-    FiniteField,
-    LaurentSeriesRing,
-    PolynomialRing,
-    Qp,
-    QuadraticField,
-    RealField,
-    Zmod,
-    Zp,
-    polygen,
-)
+from sage.rings.real_mpfr import RR
+from sage.rings.complex_mpfr import ComplexField
+from sage.rings.finite_rings.finite_field_constructor import FiniteField
+from sage.rings.laurent_series_ring import LaurentSeriesRing
+from sage.rings.polynomial.polynomial_ring_constructor import PolynomialRing
+from sage.rings.number_field.number_field import QuadraticField
+from sage.rings.real_mpfr import RealField
+from sage.rings.finite_rings.integer_mod_ring import IntegerModRing as Zmod
+from sage.rings.polynomial.polynomial_ring import polygen
 from sage.rings.infinity import Infinity as oo
 from sage.rings.number_field.number_field import NumberField
+from sage.rings.padics.factory import Qp, Zp
 from sage.structure.element import ModuleElement, MultiplicativeGroupElement
 from sage.structure.parent import Parent
 from sage.structure.sage_object import SageObject, load, save

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ passagemath = [
     "passagemath-groups",
     "passagemath-modules",
     "passagemath-pari",
+    "passagemath-plot",
     "passagemath-repl",
     "passagemath-schemes",
     "passagemath-symbolics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,9 @@ dependencies = []
 
 [project.optional-dependencies]
 passagemath = [
+    "passagemath-eclib",
     "passagemath-flint",
+    "passagemath-graphs",
     "passagemath-groups",
     "passagemath-modules",
     "passagemath-pari",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,17 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = []
 
+[project.optional-dependencies]
+passagemath = [
+    "passagemath-flint",
+    "passagemath-groups",
+    "passagemath-modules",
+    "passagemath-pari",
+    "passagemath-repl",
+    "passagemath-schemes",
+    "passagemath-symbolics",
+]
+
 [tool.setuptools]
 packages = [
     "darmonpoints",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+envlist = passagemath
+
+[testenv:.pkg]
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+[testenv:passagemath]
+usedevelop = True
+extras = passagemath
+
+setenv =
+    # For access to _doctest_environment.py
+    PYTHONPATH=.
+
+commands =
+    sage -tp --environment=_doctest_environment darmonpoints


### PR DESCRIPTION
https://github.com/passagemath/passagemath?tab=readme-ov-file#modularized-distributions

To test: type `tox`

-------

```
$ tox -r
passagemath: remove tox env folder /Users/mkoeppe/s/sage/darmonpoints/.tox/passagemath
.pkg: remove tox env folder /Users/mkoeppe/s/sage/darmonpoints/.tox/.pkg
.pkg: install_requires> python -I -m pip install Cython setuptools wheel
.pkg: _optional_hooks> python /usr/local/Cellar/tox/4.14.2/libexec/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: get_requires_for_build_editable> python /usr/local/Cellar/tox/4.14.2/libexec/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
.pkg: build_editable> python /usr/local/Cellar/tox/4.14.2/libexec/lib/python3.12/site-packages/pyproject_api/_backend.py True setuptools.build_meta
passagemath: install_package_deps> python -I -m pip install passagemath-eclib passagemath-flint passagemath-graphs passagemath-groups passagemath-modules passagemath-pari passagemath-plot passagemath-repl passagemath-schemes passagemath-symbolics
passagemath: install_package> python -I -m pip install --force-reinstall --no-deps /Users/mkoeppe/s/sage/darmonpoints/.tox/.tmp/package/7/darmonpoints-7.0.1-0.editable-cp312-cp312-macosx_14_0_x86_64.whl
passagemath: commands[0]> sage -tp --environment=_doctest_environment darmonpoints
Running doctests with ID 2025-05-29-07-53-29-0d6b87a6.
Running with SAGE_LOCAL='/Users/mkoeppe/s/sage/darmonpoints/.tox/passagemath' and SAGE_VENV='/Users/mkoeppe/s/sage/darmonpoints/.tox/passagemath'
Using --optional=pip,sage
Features to be detected: 4ti2,SAGE_SRC,benzene,bliss,buckygen,cddexec,cddexec_gmp,conway_polynomials,coxeter3,csdp,cvxopt,cvxopt,cvxpy,database_cremona_ellcurve,database_cremona_mini_ellcurve,database_cubic_hecke,database_ellcurves,database_graphs,database_jones_numfield,database_knotinfo,dot2tex,dvipng,eclib,ecm,fpylll,fricas,frobby,gap_package_atlasrep,gap_package_design,gap_package_grape,gap_package_guava,gap_package_hap,gap_package_polenta,gap_package_polycyclic,gap_package_qpa,gap_package_quagroup,gfan,giac,glucose,graphviz,imagemagick,info,ipython,jmol,jupymake,jupyter_sphinx,kenzo,kissat,latte_int,lrcalc_python,lrslib,macaulay2,mathics,matroid_database,mcqd,meataxe,mpmath,msolve,nauty,networkx,numpy,palp,pandoc,pdf2svg,pdftocairo,pexpect,phitigra,pillow,plantri,polytopes_db,polytopes_db_4d,pplpy,primecountpy,ptyprocess,pycosat,pycryptosat,pynormaliz,pyparsing,pytest,python_igraph,qepcad,requests,rpy2,rubiks,sage.all,sage.combinat,sage.geometry.polyhedron,sage.graphs,sage.groups,sage.libs.braiding,sage.libs.cmr,sage.libs.ecl,sage.libs.flint,sage.libs.gap,sage.libs.giac,sage.libs.homfly,sage.libs.iml,sage.libs.linbox,sage.libs.m4ri,sage.libs.ntl,sage.libs.pari,sage.libs.singular,sage.misc.cython,sage.modular,sage.modules,sage.numerical.mip,sage.plot,sage.rings.complex_double,sage.rings.complex_interval_field,sage.rings.finite_rings,sage.rings.function_field,sage.rings.number_field,sage.rings.padics,sage.rings.polynomial.pbori,sage.rings.real_double,sage.rings.real_interval_field,sage.rings.real_mpfr,sage.sat,sage.schemes,sage.symbolic,sage_numerical_backends_coin,sagemath_doc_html,scipy,singular,sirocco,sloane_database,sphinx,symengine_py,sympow,sympy,tdlib,threejs,topcom
Sorting sources by runtime so that slower doctests are run first....
Doctesting 41 files using 8 threads.
// ** Could not find dynamic library: p_Procs_FieldIndep.so (path /Users/mkoeppe/s/sage/darmonpoints/.tox/passagemath/lib/python3.12/site-packages/sage_wheels/bin/..)
// ** Singular will work properly, but much slower.
// ** See the INSTALL section in the Singular manual for details.
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/divisors.py
    [8 tests, 3.83s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/mixed_extension.pyx
    [18 tests, 3.84s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/ocbianchi.py
    [57 tests, 4.02s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/arithgroup.py
    [6 tests, 0.27s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/darmonvonk.py
    [1 test, 0.09s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/cohomology_abstract.py
    [5 tests, 0.09s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/arithgroup_generic.py
    [1 test, 0.10s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/sarithgroup.py
    [2 tests, 0.10s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/representations.py
    [3 tests, 0.09s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/homology.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/arithgroup_element.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/integrals.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/bianchi_lseries.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/padicperiods.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/homology_abstract.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/limits.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/arithgroup_nscartan.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/rationalfunctions.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic_debug.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic_ps.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic_list.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/plectic.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic_ps_dlog.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/theta.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/meromorphic_ps_log.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/find_many_curves.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/sparse.pyx
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/tables/all_fields_atr.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/tables/all_fields.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/tables/all_fields_tr.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/systematic_search.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/__init__.py
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/find_candidate_parameters.sage
    [0 tests, 0.00s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/schottky.py
    [32 tests, 8.07s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/cohomology_arithmetic.py
    [8 tests, 6.08s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/findcurve.py
    [9 tests, 6.14s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/my_p1list_nf.py
    [121 tests, 10.12s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/ocmodule.py
    [29 tests, 17.59s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/util.py
    [58 tests, 31.08s wall]
sage -t --warn-long 5.0 --random-seed=129086843011605063513491913635489914732 --environment=_doctest_environment darmonpoints/darmonpoints.py
**********************************************************************
File "darmonpoints/darmonpoints.py", line 190, in darmonpoints.darmonpoints.?
Warning: slow doctest:
    darmon_point(7,EllipticCurve('35a1'),41,20, cohomological=False, use_magma=False, use_ps_dists = True)[0]
Test ran for 26.30s cpu, 51.93s wall
Check ran for 0.00s cpu, 0.00s wall
    [9 tests, 55.97s wall]
----------------------------------------------------------------------
All tests passed!
----------------------------------------------------------------------
Total time for all tests: 56.0 seconds
    cpu time: 42.2 seconds
    cumulative wall time: 147.5 seconds
```
