### PR TITLE
Fix ArithGroup and BigArithGroup classes to properly work with level

### DIFF
--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -1898,9 +1898,9 @@ class ArithGroup_nf_generic(ArithGroup_generic):
             and K.gen(0).norm(K.base_ring()) == mu.reduced_norm()
         )
 
-        found = False
+        #found = False
         coords = lambda x: K(x).list()  # K.gen().coordinates_in_terms_of_powers()
-        phi = K.hom([mu, self.B(self.F.gen())], check=False)
+        #phi = K.hom([mu, self.B(self.F.gen())], check=False)
         u0 = find_the_unit_of(self.F, K)
         assert u0.is_integral() and (1 / u0).is_integral()
         u = u0

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -901,9 +901,15 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
             self._Omax_magma = info_magma._Omax_magma
             if O_magma is None:
                 if self.level != ZZ(1):
-                    self._O_magma = info_magma._O_magma.pMaximalOrder(
-                        "%s*%s" % (ZZ(info_magma.level // self.level), ZZ_magma.name())
-                    )
+                    # We compute the additional level needed to reach self.level and an Eichler order of that level.
+                    missing_level = ZZ(self.level // info_magma.level)
+                    missing_order = self._Omax_magma.Order(f"{missing_level}*{ZZ_magma.name()}")
+                    # We intersect the already computed order with the missing_order to get an order of level self.level.
+                    self._O_magma = self.magma(
+                        f"{info_magma._O_magma.name()} meet {missing_order.name()}"
+                        )
+                    assert self.magma(f"{self._O_magma.name()} meet {missing_order.name()} eq {self._O_magma.name()}")
+                    assert self.magma(f"Discriminant({self._O_magma.name()}) eq {self.level*self.discriminant}*{ZZ_magma.name()}")
                 else:
                     self._O_magma = self._Omax_magma
             else:

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -1004,7 +1004,11 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
 
         iotap = self.get_embedding(prec)
 
-        eps0 = K.units()[0] ** 2
+        eps0 = K.units()[0]
+        # Distinguish between negative and positive norm fundamental units.
+        if eps0.norm() != 1:
+            eps0 = eps0 ** 2
+        
         eps = eps0
         while coords(eps)[1] % extra_conductor != 0:
             eps *= eps0

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -108,6 +108,10 @@ def perturb_point_on_arc(x1, x2, z, r):
     ans = []
     CC = z.parent()
     rnorm = r * (z.imag() ** 2)
+    if r2 is Infinity:
+        ans.append(CC(RR(z.real() + rnorm), RR(z.imag())))
+        ans.append(CC(RR(z.real() - rnorm), RR(z.imag())))
+        return ans
     ans.append(
         CC(RR(z.real() + rnorm), RR((r2 - (z.real() + rnorm - center) ** 2).sqrt()))
     )

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -109,8 +109,8 @@ def perturb_point_on_arc(x1, x2, z, r):
     CC = z.parent()
     rnorm = r * (z.imag() ** 2)
     if r2 is Infinity:
-        ans.append(CC(RR(z.real() + rnorm), RR(z.imag())))
-        ans.append(CC(RR(z.real() - rnorm), RR(z.imag())))
+        ans.append(CC(RR(z.real()), RR(z.imag() + rnorm)))
+        ans.append(CC(RR(z.real()), RR(z.imag() - rnorm)))
         return ans
     ans.append(
         CC(RR(z.real() + rnorm), RR((r2 - (z.real() + rnorm - center) ** 2).sqrt()))

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -761,7 +761,7 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
                 return
             except OSError:
                 verbose("Will save fundamental domain data to file %s" % filename)
-                print("Initialized fundamental domain data from file %s" % filename)
+                print("Will save fundamental domain data to file %s" % filename)
                 pass
 
         Gm = self.magma.FuchsianGroup(self._O_magma.name())
@@ -869,7 +869,7 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
             verbose("Saved to file")
 
     def _init_magma_objects(
-        self, info_magma=None, O_magma=None, intersection=None
+        self, info_magma=None, O_magma=None, intersection=None, **kwargs
     ):  # Rational quaternions
         wtime = walltime()
         verbose("Calling _init_magma_objects...")
@@ -884,7 +884,12 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
                 self._B_magma = self.magma.QuaternionAlgebra(
                     "%s*%s" % (self.discriminant, ZZ_magma.name())
                 )
-            self._Omax_magma = self._B_magma.MaximalOrder()
+            Omax_magma = kwargs.get("Omax_magma", None)
+            if Omax_magma is None:
+                self._Omax_magma = self._B_magma.MaximalOrder()
+            else:
+                self._Omax_magma = self.magma.Order([self._B_magma(o) for o in Omax_magma])
+
             if O_magma is None:
                 if self.level != ZZ(1):
                     self._O_magma = self._Omax_magma.Order(
@@ -966,9 +971,9 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
         sage: G = ArithGroup(QQ,6,magma=Magma()) # optional - magma
         sage: f = G.embed_order(23,20) # optional - magma
         """
-        mu = kwargs.get(
-            "quadratic_embedding", self.compute_quadratic_embedding(D, **kwargs)
-        )
+        mu = kwargs.get("quadratic_embedding", None)
+        if mu is None:
+            mu = self.compute_quadratic_embedding(D, **kwargs)
         F = self.base_ring()
         t = PolynomialRing(F, names="t").gen()
         K = F.extension(t * t - D, names="beta")

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -411,6 +411,8 @@ class ArithGroup_fuchsian_generic(ArithGroup_generic):
             x1, x2 = t0, act_flt(emb(self(g**-1).quaternion_rep), x2)
 
         # Here we can assume that x1 is in the fundamental domain
+        if not self.is_in_fundom(x1):
+            verbose("x1 is not in the fundamental domain, but we are assuming it is...")
         ans = [self(g)]
         while not self.is_in_fundom(x2):
             intersection_candidates = []

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -200,10 +200,10 @@ def sorted_ideal_endpoints(geodesic):
     M = geodesic._model
     # infinity is the first endpoint, so the other ideal endpoint
     # is just the real part of the second coordinate
-    if start == Infinity:
+    if is_infinity(start):
         return [M.get_point(start), M.get_point(x2)]
     # Same idea as above
-    if end == Infinity:
+    if is_infinity(end):
         return [M.get_point(x1), M.get_point(end)]
     # We could also have a vertical line with two interior points
     if x1 == x2:
@@ -236,7 +236,7 @@ def moebius_transform(A, z):
     """
     if A.ncols() == 2 and A.nrows() == 2 and A.det() != 0:
         (a, b, c, d) = A.list()
-        if z == Infinity:
+        if is_infinity(z):
             if c == 0:
                 return Infinity
             return a / c
@@ -260,13 +260,13 @@ def angle_sign(left, right):  # UHP
     """
     (p1, p2) = (k.coordinates() for k in sorted_ideal_endpoints(left))
     (q1, q2) = (k.coordinates() for k in sorted_ideal_endpoints(right))
-    if p1 != Infinity and p2 != Infinity:  # geodesic not a straight line
+    if not is_infinity(p1) and not is_infinity(p2):  # geodesic not a straight line
         # So we send it to the geodesic with endpoints [0, oo]
         T = HyperbolicGeodesicUHP._crossratio_matrix(p1, (p1 + p2) / 2, p2)
     else:
         # geodesic is a straight line, so we send it to the geodesic
         # with endpoints [0,oo]
-        if p1 == Infinity:
+        if is_infinity(p1):
             T = HyperbolicGeodesicUHP._crossratio_matrix(p1, p2 + 1, p2)
         else:
             T = HyperbolicGeodesicUHP._crossratio_matrix(p1, p1 + 1, p2)
@@ -275,7 +275,7 @@ def angle_sign(left, right):  # UHP
         q1, q2 = q2, q1
     b1, b2 = (moebius_transform(T, k) for k in [q1, q2])
     # If right is now a straight line...
-    if b1 == Infinity or b2 == Infinity:
+    if is_infinity(b1) or is_infinity(b2):
         # then since they intersect, they are equal
         return ZZ(0)
     assert b1 * b2 < 0
@@ -1271,7 +1271,7 @@ class ArithGroup_rationalmatrix(ArithGroup_matrix_generic):
     def is_in_fundom(self, t, v0=None):
         if v0 is None:
             v0 = lambda x: x
-        if t is Infinity or t == Infinity:
+        if is_infinity(t):
             return True
         else:
             return 2 * t.real_part().abs() <= 1 and t.norm() >= 1
@@ -1325,7 +1325,7 @@ class ArithGroup_rationalmatrix(ArithGroup_matrix_generic):
             v0 = lambda x: x
 
         # We first deal with the case of x1 or x2 being Infinity
-        if x1 == Infinity or x2 == Infinity:
+        if is_infinity(x1) or is_infinity(x2):
             raise NotImplementedError
 
         verbose("Calling mat_list with x1 = %s and x2 = %s" % (x1, x2))

--- a/darmonpoints/arithgroup_element.py
+++ b/darmonpoints/arithgroup_element.py
@@ -221,7 +221,13 @@ class ArithGroupElement(MultiplicativeGroupElement):
             is_field = False
         if is_field:
             a, b, c, d = mat.list()
-            return (a * x + b) / (c * x + d)
+            if is_infinity(x):
+                if c == 0:
+                    return x
+                else:
+                    return a / c
+            else:
+                return (a * x + b) / (c * x + d)
         else:
             try:
                 return mat * x

--- a/darmonpoints/arithgroup_generic.py
+++ b/darmonpoints/arithgroup_generic.py
@@ -330,7 +330,7 @@ class ArithGroup_generic(AlgebraicGroup):
         sage: G = ArithGroup(QQ,6,None,5,magma=Magma()) # optional - magma
         sage: reps = G.get_hecke_reps(11) # optional - magma
         """
-        if l == Infinity:
+        if is_infinity(l):
             reps = [self.non_positive_unit()]
         elif l == -Infinity:
             reps = [self.wp()]

--- a/darmonpoints/darmonvonk.py
+++ b/darmonpoints/darmonvonk.py
@@ -589,7 +589,7 @@ def darmon_vonk_point(
     return ans_list
 
 
-def admissible_discriminants(p, D, bound, magma=None):
+def admissible_discriminants(p, D, bound, level=1, magma=None):
     if magma is None:
         from sage.interfaces.magma import Magma
 
@@ -618,10 +618,13 @@ def admissible_discriminants(p, D, bound, magma=None):
     except AttributeError:
         F = QQ
         facts = [o[0] for o in ZZ(D).factor()] + [ZZ(p)]
+        facts_level = [o[0] for o in ZZ(level).factor()]
         for n in range(1, bound):
             if n != fundamental_discriminant(n):
                 continue
-            if all(kronecker_symbol(n, ell) in [-1, 0] for ell in facts) and n % p != 0:
+            field_embeddable = all(kronecker_symbol(n, ell) in [-1, 0] for ell in facts)
+            level_embeddable = all(kronecker_symbol(n, ell) in [1, 0] for ell in facts_level)
+            if field_embeddable and level_embeddable and n % p != 0:
                 ans.append(n)
     return ans
 

--- a/darmonpoints/darmonvonk.py
+++ b/darmonpoints/darmonvonk.py
@@ -696,6 +696,7 @@ def darmon_vonk_cycle(
     padic_field=None,
     hecke_data=None,
     outfile=None,
+    extra_data=False,
     **kwargs,
 ):
     p = G.prime()
@@ -739,6 +740,8 @@ def darmon_vonk_cycle(
         theta, mult = ans0.zero_degree_equivalent(allow_multiple=True)
     else:
         theta, mult = ans0, 1
+    if extra_data:
+        return theta, mult * scaling, gamma_zeta, zeta
     return theta, mult * scaling
 
 
@@ -824,6 +827,7 @@ class DVCocycle(SageObject):
         Returns a list S of matrices in G satisfying
         g * (x1, gamma1*x1) meets (x2, gamma2*x2) => g belongs to S.
         """
+        verbose("Finding all matrix candidates for gamma = %s" % gamma)
         x0 = self._x0
         gamma1 = self._gamma_tau
         x1 = self._t0
@@ -833,6 +837,7 @@ class DVCocycle(SageObject):
         return [self._G(o) for o in list(set(ans))]
 
     def evaluate(self, gamma):
+        verbose("Called evaluate at gamma = %s" % gamma)
         HH = HyperbolicPlane().UHP()
         Div = Divisors(self._tau.parent())
         if gamma.quaternion_rep == 1 or gamma.quaternion_rep == -1:

--- a/darmonpoints/divisors.py
+++ b/darmonpoints/divisors.py
@@ -30,6 +30,7 @@ from sage.structure.unique_representation import (
     UniqueRepresentation,
 )
 
+from .util import is_infinity
 
 # Returns a hash of an element of Cp (which is a quadratic extension of Qp)
 def _hash(x):

--- a/darmonpoints/divisors.py
+++ b/darmonpoints/divisors.py
@@ -212,7 +212,7 @@ class DivisorsElement(ModuleElement):
         newdict = defaultdict(ZZ)
         new_ptdata = {}
         for P, n in self:
-            if P == Infinity:
+            if is_infinity(P):
                 try:
                     new_pt = a / c
                 except (PrecisionError, ZeroDivisionError):

--- a/darmonpoints/plectic.py
+++ b/darmonpoints/plectic.py
@@ -124,22 +124,25 @@ class PlecticGroup_class(AlgebraicGroup):
         **kwargs,
     ):
         self.F = base
-        self.GS = ArithGroup(
-            base,
-            discriminant,
-            abtuple,
-            p0 * p1 * level,
-            info_magma=kwargs.pop("info_magma", None),
-            magma=magma,
-            compute_presentation=False,
-            **kwargs,
-        )
+        info_magma = kwargs.pop("info_magma", None)
+        if info_magma is None:
+            G_base_n = ArithGroup(
+                base,
+                discriminant,
+                abtuple,
+                level,
+                info_magma=None,
+                magma=magma,
+                compute_presentation=False,
+                **kwargs,
+            )
+            info_magma = G_base_n
         Gp0 = ArithGroup(
             base,
             discriminant,
             abtuple,
             p0 * level,
-            info_magma=self.GS,
+            info_magma=info_magma,
             magma=magma,
             compute_presentation=False,
             **kwargs,
@@ -149,7 +152,18 @@ class PlecticGroup_class(AlgebraicGroup):
             discriminant,
             abtuple,
             p1 * level,
-            info_magma=self.GS,
+            info_magma=info_magma,
+            magma=magma,
+            compute_presentation=False,
+            **kwargs,
+        )
+        self.GS = ArithGroup(
+            base,
+            discriminant,
+            abtuple,
+            p0 * p1 * level,
+            info_magma=Gp1,
+            intersection=Gp0,
             magma=magma,
             compute_presentation=False,
             **kwargs,

--- a/darmonpoints/plectic.py
+++ b/darmonpoints/plectic.py
@@ -192,13 +192,6 @@ class PlecticGroup_class(AlgebraicGroup):
             magma=magma,
             **kwargs,
         )
-        if not all(
-            [
-                G0.Gpn._is_in_order(g) and G0.Gn._is_in_order(g)
-                for g in self.GS._get_O_basis()
-            ]
-        ):
-            raise RuntimeError("Try again later...")
 
         kwargs["Gn"] = G0.Gpn
         kwargs["Gpn"] = G0.Gn
@@ -214,13 +207,6 @@ class PlecticGroup_class(AlgebraicGroup):
             magma=magma,
             **kwargs,
         )
-        if not all(
-            [
-                G1.Gpn._is_in_order(g) and G1.Gn._is_in_order(g)
-                for g in self.GS._get_O_basis()
-            ]
-        ):
-            raise RuntimeError("Try again later...")
 
         self.GG = [G0, G1]
         self.ideal_p0 = G0.ideal_p

--- a/darmonpoints/sarithgroup.py
+++ b/darmonpoints/sarithgroup.py
@@ -266,28 +266,9 @@ class BigArithGroup_class(AlgebraicGroup):
         verbose("Estimated Difficulty = %s" % difficulty)
 
         info_magma = kwargs.pop("info_magma", None)
-        verbose("Initializing arithmetic group G(pn)...")
-        kwargs["O_magma"] = kwargs.pop("GpnBasis", None)
-        t = walltime()
-        lev = self.ideal_p * self.level
-        if character is not None:
-            lev = [lev, character]
-        self.Gpn = kwargs.get("Gpn", None)
-        if self.Gpn is None:
-            self.Gpn = ArithGroup(
-                self.F,
-                self.discriminant,
-                abtuple,
-                lev,
-                info_magma=info_magma,
-                magma=magma,
-                compute_presentation=not self._use_shapiro,
-                **kwargs,
-            )
-        self.Gpn.get_embedding = self.get_embedding
-        self.Gpn.embed = self.embed
 
         verbose("Initializing arithmetic group G(n)...")
+        t = walltime()
         q = kwargs.get("extra_q", 1)
         self.ideal_q = Fideal(q)
         lev = self.ideal_q * self.level
@@ -296,8 +277,6 @@ class BigArithGroup_class(AlgebraicGroup):
         kwargs["O_magma"] = kwargs.pop("GnBasis", None)
         self.Gn = kwargs.get("Gn", None)
         if self.Gn is None:
-            if info_magma is None:
-                info_magma = self.Gpn
             self.Gn = ArithGroup(
                 self.F,
                 self.discriminant,
@@ -308,11 +287,33 @@ class BigArithGroup_class(AlgebraicGroup):
                 compute_presentation=True,
                 **kwargs,
             )
+        self.Gn.embed = self.embed
+        self.Gn.get_embedding = self.get_embedding
+
+        verbose("Initializing arithmetic group G(pn)...")
+        kwargs["O_magma"] = kwargs.pop("GpnBasis", None)
+        lev = self.ideal_p * self.level
+        if character is not None:
+            lev = [lev, character]
+        self.Gpn = kwargs.get("Gpn", None)
+        if self.Gpn is None:
+            if info_magma is None:
+                info_magma = self.Gn
+            self.Gpn = ArithGroup(
+                self.F,
+                self.discriminant,
+                abtuple,
+                lev,
+                info_magma=info_magma,
+                magma=magma,
+                compute_presentation=not self._use_shapiro,
+                **kwargs,
+            )
         t = walltime(t)
         verbose("Time for calculation T = %s" % t)
         verbose("T = %s x difficulty" % RealField(25)(t / difficulty))
-        self.Gn.embed = self.embed
-        self.Gn.get_embedding = self.get_embedding
+        self.Gpn.get_embedding = self.get_embedding
+        self.Gpn.embed = self.embed
 
         if hasattr(self.Gpn.B, "is_division_algebra"):
             fwrite(

--- a/darmonpoints/util.py
+++ b/darmonpoints/util.py
@@ -334,7 +334,7 @@ def act_flt(g, x):
         try:
             K = K.base_ring()
         except AttributeError: pass
-    if x == Infinity:
+    if is_infinity(x):
         return a / c
     if K(c) * x + K(d) == 0:
         return Infinity


### PR DESCRIPTION
This branch fixes:

- BigArithGroup does not always create large_group() with the passed level.
- ArithGroup does not create a group with the correct level when passed the option info_magma.
- PlecticGroup fails to build groups contained in each other.
- ArithGroup_nf_generic.embed_order fails due to the presence of unused code.
- perturb_point_on_arc wrongly perturbs a point along a line geodesic.
- ArithGroup_rationalquaternion.embed_order sometimes chooses the square of the norm 1 unit generator.

This branch adds:

- Rational and NF quaternion ArithGroups can now be generated via the intersection of two other ArithGroups. These need to be passed via the "info_magma" and "intersection" kwargs.
- Now admissible_discriminants can be used to find admissible discriminants for finding DV points with level.
- Some more verbosity information and debugging capabilities.
