### PR TITLE
Fix zero_degree_equivalent and Hecke operator consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /rever
 /darmonpoints/*.c
 /darmonpoints.egg-info
+/darmonpoints/*.so
+/darmonpoints/__pycache__
+.gitignore

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -1062,10 +1062,11 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
         )
     )
     def element_of_norm(
-        self, N, use_magma=True, return_all=False, radius=-1, max_elements=-1
+        self, N, use_magma=True, return_all=False, radius=-1, max_elements=-1, force_sign=None
     ):  # in rationalquaternion
         N = ZZ(N)
-        force_sign = "P" not in self._grouptype
+        if force_sign is None:
+            force_sign = "P" not in self._grouptype
         if use_magma:
             # assert return_all == False
             elt_magma = self._O_magma.ElementOfNorm(N * self._F_magma.Integers())
@@ -1598,7 +1599,7 @@ class ArithGroup_rationalmatrix(ArithGroup_matrix_generic):
         )
     )
     def element_of_norm(
-        self, N, use_magma=False, return_all=False, radius=None, max_elements=None
+        self, N, use_magma=False, return_all=False, radius=None, max_elements=None, force_sign=None
     ):  # in rationalmatrix
         candidate = self.B([N, 0, 0, 1])
         set_immutable(candidate)
@@ -2005,14 +2006,15 @@ class ArithGroup_nf_generic(ArithGroup_generic):
         )
     )
     def element_of_norm(
-        self, N, use_magma=True, return_all=False, radius=-1, max_elements=-1
+        self, N, use_magma=True, return_all=False, radius=-1, max_elements=-1, force_sign=None
     ):  # in nf_generic
         Nideal = self.F.ideal(N)
         try:
             N = N.gens_reduced()[0]
         except AttributeError:
             pass
-        force_sign = "P" not in self._grouptype
+        if force_sign is None:
+            force_sign = "P" not in self._grouptype
         if return_all and radius < 0 and max_elements < 0:
             raise ValueError("Radius must be positive")
 
@@ -2873,7 +2875,7 @@ class ArithGroup_nf_matrix(ArithGroup_nf_kleinian, ArithGroup_matrix_generic):
         )
     )
     def element_of_norm(
-        self, N, use_magma=False, return_all=False, radius=None, max_elements=None
+        self, N, use_magma=False, return_all=False, radius=None, max_elements=None, force_sign=None
     ):  # in nf_matrix
         mat = matrix(2, 2, [self.F.ideal(N).gens_reduced()[0], 0, 0, 1])
         candidate = self.matrix_to_quaternion(mat)

--- a/darmonpoints/arithgroup.py
+++ b/darmonpoints/arithgroup.py
@@ -1054,7 +1054,7 @@ class ArithGroup_rationalquaternion(ArithGroup_fuchsian_generic):
             return gamma, tau1
 
     @cached_method(
-        key=lambda self, N, use_magma, return_all, radius, max_elements: (
+        key=lambda self, N, use_magma, return_all, radius, max_elements, force_sign: (
             self,
             N,
             return_all,
@@ -1592,7 +1592,7 @@ class ArithGroup_rationalmatrix(ArithGroup_matrix_generic):
             return self.check_word(delta.matrix(), ans)
 
     @cached_method(
-        key=lambda self, N, use_magma, return_all, radius, max_elements: (
+        key=lambda self, N, use_magma, return_all, radius, max_elements, force_sign: (
             self,
             N,
             return_all,
@@ -1998,7 +1998,7 @@ class ArithGroup_nf_generic(ArithGroup_generic):
                     yield candidate
 
     @cached_method(
-        key=lambda self, N, use_magma, return_all, radius, max_elements: (
+        key=lambda self, N, use_magma, return_all, radius, max_elements, force_sign: (
             self,
             N,
             return_all,
@@ -2868,7 +2868,7 @@ class ArithGroup_nf_matrix(ArithGroup_nf_kleinian, ArithGroup_matrix_generic):
         return [M([1, 0, 0, 1]), M([1, 0, 0, -1]), M([0, -1, -1, 0]), M([0, -1, 1, 0])]
 
     @cached_method(
-        key=lambda self, N, use_magma, return_all, radius, max_elements: (
+        key=lambda self, N, use_magma, return_all, radius, max_elements, force_sign: (
             self,
             N,
             return_all,

--- a/darmonpoints/arithgroup_generic.py
+++ b/darmonpoints/arithgroup_generic.py
@@ -336,7 +336,7 @@ class ArithGroup_generic(AlgebraicGroup):
             reps = [self.wp()]
         else:
             if g0 is None:
-                g0 = self.element_of_norm(l, use_magma=use_magma)
+                g0 = self.element_of_norm(l, use_magma=use_magma, force_sign=True)
             reps = [g0]
             I = self.enumerate_elements()
             n_iters = ZZ(0)

--- a/darmonpoints/arithgroup_generic.py
+++ b/darmonpoints/arithgroup_generic.py
@@ -508,8 +508,9 @@ class ArithGroup_generic(AlgebraicGroup):
             )
         oldwordlist = [n * x.word_rep[:] for x, n in xlist]
         ngens = len(self.gens())
+        weight_vector = list((get_weight_vector(n * x.word_rep, ngens) for x, n in xlist))
         return oldwordlist, self._calculate_relation(
-            sum((get_weight_vector(n * x.word_rep, ngens) for x, n in xlist),[]), separated=separated
+            [sum(o) for o in zip(*weight_vector)], separated=separated
         )
 
     def decompose_into_commutators(self, gamma, n=1):

--- a/darmonpoints/arithgroup_nscartan.py
+++ b/darmonpoints/arithgroup_nscartan.py
@@ -382,6 +382,7 @@ class ArithGroup_nscartan(ArithGroup_generic):
         radius=None,
         max_elements=None,
         local_condition=None,
+        force_sign=None
     ):  # in nonsplitcartan
         try:
             if return_all:

--- a/darmonpoints/divisors.py
+++ b/darmonpoints/divisors.py
@@ -301,8 +301,11 @@ class Divisors(Parent, CachedRepresentation):
         self._base = base
         Parent.__init__(self)
 
-    def _an_element_(self):
-        return self.element_class(self, [(3, self._base._an_element_())])
+    def _an_element_(self, degree=3):
+        return self.element_class(self, [(degree, self._base._an_element_())])
+
+    def an_element(self, degree=3):
+        return self._an_element_(degree=degree)
 
     def _element_constructor_(self, data, ptdata=None):
         return self.element_class(self, data, ptdata)

--- a/darmonpoints/homology.py
+++ b/darmonpoints/homology.py
@@ -32,6 +32,7 @@ from sage.structure.unique_representation import (
     CachedRepresentation,
     UniqueRepresentation,
 )
+from _warnings import warn
 
 from .divisors import *
 from .homology_abstract import ArithHomology, HomologyGroup
@@ -225,8 +226,9 @@ class OneChainsElement(TensorElement):
     def is_degree_zero_valued(self, degree_map=None):
         if isinstance(self.parent().coefficient_module(), Divisors):
             if degree_map is not None:
-                raise ValueError('degree_map should not be provided when the coefficient module is divisors')
-            degree_map = lambda v: v.degree()
+                warn('Using provided degree_map')
+            else:
+                degree_map = lambda v: v.degree()
         if degree_map is None:
             raise NotImplementedError(
                 "zero_degree_equivalent only implemented for divisors coefficient module, or with a degree_map provided"
@@ -251,8 +253,9 @@ class OneChainsElement(TensorElement):
         """
         if isinstance(self.parent().coefficient_module(), Divisors):
             if degree_map is not None:
-                raise ValueError('degree_map should not be provided when the coefficient module is divisors')
-            degree_map = lambda v: v.degree()
+                warn('Using provided degree_map')
+            else:
+                degree_map = lambda v: v.degree()
         if degree_map is None:
             raise NotImplementedError(
                 "zero_degree_equivalent only implemented for divisors coefficient module, or with a degree_map provided"
@@ -262,11 +265,13 @@ class OneChainsElement(TensorElement):
         HH = self.parent()
         V = HH.coefficient_module()
         G = HH.group()
-        aux_element = V.an_element()
         Gab = G.abelianization()
+        aux_element = V.an_element()
+        oldvals = list(self._data.values())
         xlist = [(g, degree_map(v)) for g, v in zip(self._data.keys(), oldvals)]
         sum_abxlist = sum([Gab((x, n)) for x, n in xlist])
         x_ord = sum_abxlist.order()
+        print(f"{x_ord = }")
         if x_ord == Infinity or (x_ord > 1 and not allow_multiple):
             raise ValueError(
                 "Must yield torsion element in abelianization (%s, order = %s)"
@@ -275,9 +280,10 @@ class OneChainsElement(TensorElement):
         else:
             xlist = [(x, x_ord * n) for x, n in xlist]
         gwordlist, rel = G.calculate_weight_zero_word(xlist, separated=True)
-        oldvals = list(self._data.values())
         counter = 0
         assert len(gwordlist) == len(oldvals)
+        verbose(f"{gwordlist=}")
+        verbose(f"{oldvals=}")
         newdict = defaultdict(V)
         for gword, v in zip(gwordlist, oldvals):
             print("Processing %s|%s" % (gword, v))
@@ -302,7 +308,7 @@ class OneChainsElement(TensorElement):
             )
         for b, r in rel:
             print("Processing relation %s with coefficient %s" % (r, b))
-            newv = V(aux_element)
+            newv = V(x_ord*oldvals[0])
             for i, a in tietze_to_syllables(r):
                 oldv = V(newv)
                 g = G.gen(i)
@@ -318,6 +324,7 @@ class OneChainsElement(TensorElement):
                     oldv = (g**-1) * oldv
         verbose("Done zero_degree_equivalent")
         ans = HH(newdict)
+        
         if not ans.is_degree_zero_valued(degree_map=degree_map):
             print(
                 "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/darmonpoints/homology.py
+++ b/darmonpoints/homology.py
@@ -283,8 +283,9 @@ class OneChainsElement(TensorElement):
         else:
             # We adjust the weight of our 1-chain to be as x_ord * C, which is trivial in the abelianization
             xlist = [(x, x_ord * n) for x, n in xlist]
+            gwordlist = [x.word_rep for x, n in xlist]
         # Let C be our 1-chain, degC \in R^{ab}, so we find the relations in R^{ab} that satisfy degC + \sum r_i^{ab} = 0 in F^{ab}
-        gwordlist, rel = G.calculate_weight_zero_word(xlist, separated=True)
+        _, rel = G.calculate_weight_zero_word(xlist, separated=True)
         counter = 0
         assert len(gwordlist) == len(oldvals)
         verbose(f"{gwordlist=}")
@@ -297,7 +298,7 @@ class OneChainsElement(TensorElement):
         # We store all 1-boundaries used in boundary_list
         for gword, v in zip(gwordlist, oldvals):
             print("Processing %s|%s" % (gword, v))
-            newv = V(v)
+            newv = V(x_ord*v)
             for i, a in tietze_to_syllables(gword): # gi^a|v
                 oldv = V(newv)
                 g = G.gen(i)
@@ -316,14 +317,14 @@ class OneChainsElement(TensorElement):
                 float(QQ(counter) / QQ(len(oldvals))),
                 "Reducing to degree zero equivalent",
             )
-        # Generate a random degree 1 element of V to use in the relations
-        aux_element = V.an_element()
+        # Generate a generic degree 1 element of V to use in the relations
+        aux_element = V.an_element(degree=1)
         verbose(f"{aux_element=}")
         # We decompose each tensor (r_i, v) into a sum of tensors of the form (g_i, v_i) where g_i is a generator of G
         # We store all 1-boundaries used in boundary_list
         for b, r in rel:
             print("Processing relation %s with coefficient %s" % (r, b))
-            newv = V(oldvals[0])
+            newv = V(aux_element)
             for i, a in tietze_to_syllables(r):
                 oldv = V(newv)
                 g = G.gen(i)

--- a/darmonpoints/homology.py
+++ b/darmonpoints/homology.py
@@ -261,30 +261,42 @@ class OneChainsElement(TensorElement):
                 "zero_degree_equivalent only implemented for divisors coefficient module, or with a degree_map provided"
             )
         verbose("Entering zero_degree_equivalent")
-        boundary_list= []
         HH = self.parent()
         V = HH.coefficient_module()
-        G = HH.group()
-        Gab = G.abelianization()
-        aux_element = V.an_element()
+        G = HH.group() # Arithmetic group G = F/R
+        Gab = G.abelianization() # G^{ab} = F^{ab}/R^{ab}
+        # The elements of V forming the 1-chain, which are paired with the elements of G in self._data.keys()
         oldvals = list(self._data.values())
+        # xlist represents taking the degree map of the divisor
         xlist = [(g, degree_map(v)) for g, v in zip(self._data.keys(), oldvals)]
+        # We interpret xlist as an element of the abelianization of G
         sum_abxlist = sum([Gab((x, n)) for x, n in xlist])
+        # Order in the abelianization
         x_ord = sum_abxlist.order()
         print(f"{x_ord = }")
+        # We need a torsion element in the abelianization to reduce to degree zero
         if x_ord == Infinity or (x_ord > 1 and not allow_multiple):
             raise ValueError(
                 "Must yield torsion element in abelianization (%s, order = %s)"
                 % (sum_abxlist, x_ord)
-            )
+            ) # TODO: if x_ord is Infinity, find a Hecke operator that kills it, and apply it to reduce to torsion
         else:
+            # We change our 1-chain to be x_ord * C, which is trivial in the abelianization
             xlist = [(x, x_ord * n) for x, n in xlist]
-        gwordlist, rel = G.calculate_weight_zero_word(xlist, separated=True)
+        # We store the word representation of the elements of G in xlist
+        gwordlist = [x.word_rep[:] for x, n in xlist]
+        # Let C be our 1-chain, degC \in R^{ab}, so we find the relations in R^{ab} that satisfy degC + \sum r_i^{ab} = 0 in F^{ab}
+        _, rel = G.calculate_weight_zero_word(xlist, separated=True)
         counter = 0
         assert len(gwordlist) == len(oldvals)
         verbose(f"{gwordlist=}")
         verbose(f"{oldvals=}")
+        # For an arbitrary element v of V, \sum r_i \otimes v is a 1-boundary
+        # newdict will store the new 1-chain formed by C + \sum r_i \otimes v
         newdict = defaultdict(V)
+        boundary_list= []
+        # Decompose each (g,v) tensor in the 1-cycle into a sum of tensors of the form (g_i, v_i) where g_i is a generator of G
+        # We store all 1-boundaries used in boundary_list
         for gword, v in zip(gwordlist, oldvals):
             print("Processing %s|%s" % (gword, v))
             newv = V(x_ord * v)
@@ -306,9 +318,13 @@ class OneChainsElement(TensorElement):
                 float(QQ(counter) / QQ(len(oldvals))),
                 "Reducing to degree zero equivalent",
             )
+        # Generate a random degree 1 element of V to use in the relations
+        aux_element = V.an_element()
+        # We decompose each tensor (r_i, v) into a sum of tensors of the form (g_i, v_i) where g_i is a generator of G
+        # We store all 1-boundaries used in boundary_list
         for b, r in rel:
             print("Processing relation %s with coefficient %s" % (r, b))
-            newv = V(x_ord*oldvals[0])
+            newv = V(x_ord*aux_element)
             for i, a in tietze_to_syllables(r):
                 oldv = V(newv)
                 g = G.gen(i)
@@ -324,7 +340,7 @@ class OneChainsElement(TensorElement):
                     oldv = (g**-1) * oldv
         verbose("Done zero_degree_equivalent")
         ans = HH(newdict)
-        
+        # The final result should be valued in degree-zero divisors
         if not ans.is_degree_zero_valued(degree_map=degree_map):
             print(
                 "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"

--- a/darmonpoints/homology.py
+++ b/darmonpoints/homology.py
@@ -281,12 +281,10 @@ class OneChainsElement(TensorElement):
                 % (sum_abxlist, x_ord)
             ) # TODO: if x_ord is Infinity, find a Hecke operator that kills it, and apply it to reduce to torsion
         else:
-            # We change our 1-chain to be x_ord * C, which is trivial in the abelianization
+            # We adjust the weight of our 1-chain to be as x_ord * C, which is trivial in the abelianization
             xlist = [(x, x_ord * n) for x, n in xlist]
-        # We store the word representation of the elements of G in xlist
-        gwordlist = [x.word_rep[:] for x, n in xlist]
         # Let C be our 1-chain, degC \in R^{ab}, so we find the relations in R^{ab} that satisfy degC + \sum r_i^{ab} = 0 in F^{ab}
-        _, rel = G.calculate_weight_zero_word(xlist, separated=True)
+        gwordlist, rel = G.calculate_weight_zero_word(xlist, separated=True)
         counter = 0
         assert len(gwordlist) == len(oldvals)
         verbose(f"{gwordlist=}")
@@ -299,7 +297,7 @@ class OneChainsElement(TensorElement):
         # We store all 1-boundaries used in boundary_list
         for gword, v in zip(gwordlist, oldvals):
             print("Processing %s|%s" % (gword, v))
-            newv = V(x_ord * v)
+            newv = V(v)
             for i, a in tietze_to_syllables(gword): # gi^a|v
                 oldv = V(newv)
                 g = G.gen(i)
@@ -320,11 +318,12 @@ class OneChainsElement(TensorElement):
             )
         # Generate a random degree 1 element of V to use in the relations
         aux_element = V.an_element()
+        verbose(f"{aux_element=}")
         # We decompose each tensor (r_i, v) into a sum of tensors of the form (g_i, v_i) where g_i is a generator of G
         # We store all 1-boundaries used in boundary_list
         for b, r in rel:
             print("Processing relation %s with coefficient %s" % (r, b))
-            newv = V(x_ord*aux_element)
+            newv = V(oldvals[0])
             for i, a in tietze_to_syllables(r):
                 oldv = V(newv)
                 g = G.gen(i)

--- a/darmonpoints/util.py
+++ b/darmonpoints/util.py
@@ -745,7 +745,7 @@ def affine_transformation(x1p, x2p, x3p):
 
 
 def height_polynomial(x, base=10):
-    return sum((RR(o).abs() + 1).log(base) for o in x.coefficients())
+    return sum((RR(o).abs() + 1).log(base) for o in x.coefficients(sparse=False))
 
 
 def recognize_DV_algdep(


### PR DESCRIPTION
This pull request handles two different main issues:

 1. The method OneChainsElement.zero_degree_equivalent is implemented incorrectly.
 2. Randomly, requesting an ArithGroup element of norm N returns an element of norm -N.

and a minor issue:
 - util.height_polynomial fails when the passed polynomial is sparse.

The first main issue has been addressed and should now be properly implemented.

- OneChainsElement.zero_degree_equivalent has been step-by-step documented for further clarity in understanding the process.
- Fixed a bug in ArithGroup_generic.calculate_weight_zero_word when calling ArithGroup_generic._calculate_relation.
- Fixed theoretical procedure, cleaned up some variables and added verbosity.

**See the [second comment below](https://github.com/mmasdeu/darmonpoints/pull/20#issuecomment-5301887060) for information on zero_degree_equivalent's algorithm.**

The second point affects the generation of a Hecke operator for a given prime l. In general, we do not expect the operator to behave in the same way when generated using norm +l or norm -l quaternions. Experimentally, we have observed random behavior around this issue. Furthermore, this behavior is already corrected when grouptype is specified to be "SL2".

To address the second main issue, we introduce a new argument called "force_sing" passed to the ArithGroup_generic.elements_of_norm method. 

- force_sing already existed as a variable in the _rationalquaternion implementations of the method.
- force_sing's default value is None, preserving the already existing behavior
- ArithGroup_generic.get_hecke_reps now calls ArithGroup_generic.element_of_norm with forced_sign=True
- element_of_norm has been updated in all ArithGroup types to handle this new argument. 

The minor issue has been adressed by always taking polynomial coefficients with sparse=False.